### PR TITLE
More data on Ember Watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Aggregates
 
-- Ember Watch http://emberwatch.com/
+- Ember Watch - list of talks, screencasts, podcasts, books (Philip Poots) http://emberwatch.com/
 - Ember Weekly - currated list of links to resources (Owain Williams) http://emberweekly.com/
 - Ember.js Discuss - http://discuss.emberjs.com/
 


### PR DESCRIPTION
Talks not updated since the turn of the year due to initial work on refreshed site, but books and podcasts largely up-to-date.
